### PR TITLE
Fix paths in makemini build script

### DIFF
--- a/samples/makemini.bat
+++ b/samples/makemini.bat
@@ -1,5 +1,4 @@
-..\..\bin\bin\ca65 testmg.s
-..\..\bin\bin\cc65 testmgc.c
-..\..\bin\bin\ca65 testmgc.s
-
-..\..\bin\bin\ld65 -C minigame.cfg -o minigame.bin  -m minigame.map testmg.o testmgc.o ..\..\bin\runtime.lib
+..\bin\bin\ca65 testmg.s
+..\bin\bin\cc65 testmgc.c
+..\bin\bin\ca65 testmgc.s
+..\bin\bin\ld65 -C minigame.cfg -o minigame.bin  -m minigame.map testmg.o testmgc.o ..\bin\runtime.lib


### PR DESCRIPTION
The build bat file for the minigame had incorrect
directory structure for it's paths.
They now properly point up 1 directory instead of
2, in order to get to the bin folder.